### PR TITLE
Fix version in Archetype

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -14,8 +14,8 @@ cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy -DskipTests=true -B
 # Update version by 1
 newVersion=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))
 
-# Replace first occurrence of TRAVIS_TAG with newVersion appended with SNAPSHOT
-sed -i "0,/<revision>$TRAVIS_TAG/s//<revision>$newVersion-SNAPSHOT/" pom.xml
+# Use Maven to update version in all pom files
+mvn versions:set -DnewVersion=$newVersion-SNAPSHOT
 
-git commit pom.xml -m "Upgrade version to $newVersion-SNAPSHOT" --author "Github Bot <githubbot@gluonhq.com>"
+git commit pom.xml */pom.xml -m "Upgrade version to $newVersion-SNAPSHOT" --author "Github Bot <githubbot@gluonhq.com>"
 git push https://gluon-bot:$GITHUB_PASSWORD@github.com/gluonhq/client-maven-archetypes HEAD:master

--- a/client-archetype-java/pom.xml
+++ b/client-archetype-java/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>com.gluonhq</groupId>
         <artifactId>client-maven-archetypes</artifactId>
-        <version>${revision}</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 </project>

--- a/client-archetype-javafx/pom.xml
+++ b/client-archetype-javafx/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>com.gluonhq</groupId>
         <artifactId>client-maven-archetypes</artifactId>
-        <version>${revision}</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 </project>

--- a/client-archetype-mobile/pom.xml
+++ b/client-archetype-mobile/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>com.gluonhq</groupId>
         <artifactId>client-maven-archetypes</artifactId>
-        <version>${revision}</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gluonhq</groupId>
     <artifactId>client-maven-archetypes</artifactId>
-    <version>${revision}</version>
+    <version>0.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Maven Archetypes for Gluon Client</name>
     <description>Maven archetypes for creating different types of Gluon Client applications.</description>
     <url>https://gluonhq.com/</url>
-
-    <properties>
-        <revision>0.0.2-SNAPSHOT</revision>
-    </properties>
 
     <modules>
       <module>client-archetype-java</module>


### PR DESCRIPTION
It turns out Maven doesn't recognize archetypes if version uses property instead of original value. The current 0.0.1 release uses property for versions instead of actual value. I am not sure if that will work.

This is a fix for the same.